### PR TITLE
Check length before allocating and iterating

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,15 @@ function extractChunks (data) {
     uint8[2] = data[idx++]
     uint8[1] = data[idx++]
     uint8[0] = data[idx++]
+    var length = uint32[0] + 4
+
+    // The length can't be too long.
+    var maxLength = data.length - idx + 8
+    if (length > maxLength) {
+      throw new Error('Length is too large')
+    }
 
     // Chunk includes name/type for CRC check (see below).
-    var length = uint32[0] + 4
     var chunk = new Uint8Array(length)
     chunk[0] = data[idx++]
     chunk[1] = data[idx++]


### PR DESCRIPTION
If a chunk advertises a long length but that length couldn't possibly fit, we can bail early. This lets us throw an error with a more descriptive message and avoid needless operations.

Feel free to reject if this isn't helpful.