### PR TITLE
Remove test PNG from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ node_modules
 bundle.js
 test
 test.js
+test.png
 demo/
 .npmignore
 LICENSE.md


### PR DESCRIPTION
Other test files were already omitted. Removing this file cuts the package's size down by about 60KB.